### PR TITLE
Moving PR to Client 19 docs

### DIFF
--- a/content/license/_index.md
+++ b/content/license/_index.md
@@ -1,6 +1,6 @@
 +++
-title = "Apply a license in Chef Infra Client"
-linkTitle = "Apply a license"
+title = "Licensing Chef Infra Client"
+linkTitle = "Licensing"
 
 [menu.licensing]
 title = "Apply a license"
@@ -9,17 +9,65 @@ parent = "licensing"
 weight = 11
 +++
 
-Chef Infra Client 19 requires a license to run. This document describes how to set a license and verify that it's accepted.
+Before running Chef Infra Client, you must accept the Chef EULA and add a license key.
+You can [request a trial license](https://www.chef.io/license-generation-free-trial) if you'd like to try out Chef Infra Client.
 
-## Add a license
+For more information on Chef licenses, see [Chef's licensing documentation](https://docs.chef.io/licensing/).
 
-Chef Infra Client 19 has three ways to set a license:
+## Accept the Chef EULA
 
-- with an environment variable
-- with a command line option
-- with the command line interactive dialog
+You must accept the [Chef End User License Agreement (EULA)](https://www.chef.io/end-user-license-agreement) before running Chef Infra Client using one of the following methods:
 
-After setting a license key, Chef Infra Client validates it with Progress Chef's licensing service.
+- [command line option](#command-line-option)
+- [environment variable](#environment-variable)
+
+If you don't set a command line argument or environment variable, Chef Infra Client requests acceptance through an interactive prompt. If the prompt can't be displayed, then the product will fail with exit code 172.
+
+If the product attempts to persist the accepted license and fails, Chef Infra Client sends a message to STDOUT and continues to run. In a future invocation, you will need to accept the license again.
+
+### Command line option
+
+Use the `--chef-license <VALUE>` argument to accept the Chef EULA.
+
+Replace `<VALUE>` with one of the following options.
+
+`accept`
+: Accept the license and attempts to persist a marker file locally. Persisting these marker files means future invocations don't require accepting the license again.
+
+`accept-silent`
+: Similar to `accept`, but no messaging is sent to STDOUT.
+
+`accept-no-persist`
+: Similar to `accept-silent`, but no marker file is persisted. Future invocation will require accepting the license again.
+
+### Environment variable
+
+Use the `CHEF_LICENSE="<VALUE>"` environment variable to accept the Chef EULA.
+
+Replace `<VALUE>` with one of the following options:
+
+`accept`
+: Accept the license and attempts to persist a marker file locally. Persisting these marker files means future invocations don't require accepting the license again.
+
+`accept-silent`
+: Similar to `accept`, but no messaging is sent to STDOUT.
+
+`accept-no-persist`
+: Similar to `accept-silent`, but no marker file is persisted. Future invocation will require accepting the license again.
+
+## License key
+
+You can add a license key to Chef Infra Client using one of three methods:
+
+- [environment variable](#environment-variable-1)
+- [command line option](#command-line-option-1)
+- [interactive license dialog](#interactive-license-dialog)
+
+{{< note >}}
+
+Existing commercial customers of Progress Chef can use an asset serial number from the [Progress support portal](https://community.progress.com/s/products/chef) as a license key.
+
+{{< /note >}}
 
 ### Environment variable
 
@@ -39,7 +87,9 @@ After setting a license key, Chef Infra Client validates it with Progress Chef's
 
 ### Interactive license dialog
 
-If you run a `chef-client` command and a license key isn't already set, Chef Infra Client starts an interactive licensing dialog.
+The easiest way to add a license key to Chef Infra Client is to run it.
+Start a Client run and it starts an interactive licensing dialog
+if a license key isn't already set and it doesn't detect an automated method of setting the license key.
 
 To set a license key with the CLI interactive dialog, follow these steps:
 
@@ -61,7 +111,20 @@ To set a license key with the CLI interactive dialog, follow these steps:
 
 1. At the first prompt, select **I already have a license ID**.
 
-    ```text
+    ```bash
+    ------------------------------------------------------------
+      License ID Validation
+
+      To continue using Chef Infra, a license ID is required.
+      (Free, Trial, or Commercial)
+
+      If you generated a license previously, you might
+      have received it in an email.
+
+      If you are a commercial user, you can also find it in the
+      https://community.progress.com/s/products/chef portal.
+    ------------------------------------------------------------
+
     Please choose one of the options below (Press ↑/↓ arrow to move and Enter to select)
     ‣ I already have a license ID
       I don't have a license ID and would like to generate a new license ID
@@ -70,9 +133,64 @@ To set a license key with the CLI interactive dialog, follow these steps:
 
 1. Enter your license key at the second prompt.
 
-    ```text
-    Please enter your license ID:  <LICENSE_KEY>
-    ✔ [Success] License validated successfully.
-    ```
+   ```bash
+   Please choose one of the options below I already have a license ID
+   Please enter your license ID:  <LICENSE_KEY>
+   ✔ [Success] License validated successfully.
+   ------------------------------------------------------------
+   License Details
+     Asset Name       : Infra
+     License ID       : <LICENSE_KEY>
+     Type             : Trial
+     Status           : Active
+     Validity         : Unlimited
+     No. Of Units     : 10 Targets
+   ------------------------------------------------------------
+   ```
 
-    After entering the license key, Chef Infra Client verifies your license and the run completes.
+Chef Infra Client validates the license key, displays information about the license entitlements, and then executes the run.
+Infra Client stores license keys for future use and won't prompt you for the license key for the duration of your license.
+
+## Chef Local License Service
+
+For large or isolated (air-gapped) fleets, Chef Infra Client can retrieve a license key from a [Chef Local License Service](https://docs.chef.io/licensing/local_license_service/).
+With Chef Local License Service, Infra Client users don't need to know a license key---only the service URL.
+
+Chef Infra Client sends a request to the Local License Service for a list of license keys and then uses that response to license itself during execution.
+Infra Client won't prompt you for a license key.
+Infra Client doesn't store license keys for long-term use when they're retrieved from a Chef Local License Service.
+
+Use one of the following methods to set a Local License Service URL:
+
+- [command line option](#command-line-option-2)
+- [environment variable](#environment-variable-2)
+
+### Command line option
+
+- Use the `--chef-license-server` command line option to set a Chef Local License Service URL. For example:
+
+  ```bash
+  --chef-license-server https://license-server.example.com
+  ```
+
+### Environment variable
+
+- Use the `CHEF_LICENSE_SERVER` environment variable to set a Chef Local License Service URL. For example:
+
+  ```bash
+  export CHEF_LICENSE_SERVER=https://license-server.example.com
+  ```
+
+#### Multiple license servers
+
+You can deploy multiple Chef Local License Services, which provides resiliency and redundancy for managing licenses.
+
+- To set multiple Chef Local License Services, enter up to five URLs as a comma-separated list. For example:
+
+  ```bash
+  export CHEF_LICENSE_SERVER=https://license-server-01.example.com,https://license-server-02.example.com
+  ```
+
+  Chef Infra Client tries each URL and uses the first one that works.
+
+This capability is basic and you must synchronize the license servers, otherwise you may get inconsistent results.


### PR DESCRIPTION
## Description

Migrating content changes from https://github.com/chef/chef-web-docs/pull/4298

The content of this PR was started in chef/chef-web-docs#4298, but it really belongs here. So the PR moves the content here. We can release it in the RC2 or GA docs.

Mostly the difference is that it adds info about using Local License Server and accepting the Chef EULA.

## Version

These are changes for Chef Infra Client version(s):

- [ ] RC1
- [ ] RC2
- [ ] version 19

<!-- Include the version that this updates. -->

## Definition of done

## Issues resolved

- https://progresssoftware.atlassian.net/browse/CHEF-15215

## Related PRs

- https://github.com/chef/chef-web-docs/pull/4298

## Checklist

- [ ] spellcheck
- [ ] use [relref shortcode](https://gohugo.io/content-management/cross-references/#use-of-ref-and-relref) for links to Client docs in this doc set
- [ ] all tests pass
