### PR TITLE
Update S3 bucket URLs

### DIFF
--- a/content/install.md
+++ b/content/install.md
@@ -36,13 +36,13 @@ Chef Infra Client 19 RC1 is supported on Linux x86-64 systems.
     Using curl:
 
     ```sh
-    curl -o chef-migration-tool.v1.tar.gz https://chef-hab-migration-tool-bucket.s3.amazonaws.com/migration-tools_Linux_x86_64.tar.gz\?AWSAccessKeyId\=AKIAW4FPVFT6LUYZUYOB\&Signature\=FMsMGzoZe1YTYA4DbpOIEB%2FHHSw%3D\&Expires\=1740411440
+    curl -o chef-migration-tool.v1.tar.gz https://chef-hab-migration-tool-bucket.s3.amazonaws.com/migration-tools_Linux_x86_64.tar.gz\?AWSAccessKeyId\=AKIAW4FPVFT6LUYZUYOB\&Signature\=2P3xjN53%2Bib%2BnZBqFk5%2FsEORUzI%3D\&Expires\=1747912109
     ```
 
     Using Wget:
 
     ```sh
-    wget -O "chef-migration-tool.v1.tar.gz" https://chef-hab-migration-tool-bucket.s3.amazonaws.com/migration-tools_Linux_x86_64.tar.gz\?AWSAccessKeyId\=AKIAW4FPVFT6LUYZUYOB\&Signature\=FMsMGzoZe1YTYA4DbpOIEB%2FHHSw%3D\&Expires\=1740411440
+    wget -O "chef-migration-tool.v1.tar.gz" https://chef-hab-migration-tool-bucket.s3.amazonaws.com/migration-tools_Linux_x86_64.tar.gz\?AWSAccessKeyId\=AKIAW4FPVFT6LUYZUYOB\&Signature\=2P3xjN53%2Bib%2BnZBqFk5%2FsEORUzI%3D\&Expires\=1747912109
     ```
 
 1. Extract the migration tool in a temporary directory.
@@ -65,7 +65,7 @@ Chef Infra Client 19 RC1 is supported on Linux x86-64 systems.
 1. Install Chef Infra Client RC1 with the migration tool using the `apply online` command.
 
     ```sh
-    sudo ./chef-migrate apply online --fresh_install --preserve true --download.url "https://unstable-habitat-tarball.s3.amazonaws.com/chef-chef-infra-client-19.0.54-20241121145703.tar.gz?AWSAccessKeyId=AKIA2L25YRBIC3WVJTRM&Signature=XDGliip78EyaiazMnbi7N8Pao%2Bk%3D&Expires=1740407376" --license.key <VALID_LICENSE_KEY>
+    sudo ./chef-migrate apply online --fresh_install --preserve true --download.url "https://unstable-habitat-tarball.s3.amazonaws.com/chef-chef-infra-client-19.0.54-20241121145703.tar.gz?AWSAccessKeyId=AKIA2L25YRBIC3WVJTRM&Signature=Kp6oGpPRqwiNEhKh8UWlUPJZ6DU%3D&Expires=1747912507" --license.key <VALID_LICENSE_KEY>
     ```
 
     Replace `<VALID_LICENSE_KEY>` with a valid license key.

--- a/content/upgrade.md
+++ b/content/upgrade.md
@@ -60,13 +60,13 @@ Chef Infra Client 19 RC1 is supported on Linux x86-64 systems.
     Using curl:
 
     ```sh
-    curl -o chef-migration-tool.v1.tar.gz https://chef-hab-migration-tool-bucket.s3.amazonaws.com/migration-tools_Linux_x86_64.tar.gz\?AWSAccessKeyId\=AKIAW4FPVFT6LUYZUYOB\&Signature\=FMsMGzoZe1YTYA4DbpOIEB%2FHHSw%3D\&Expires\=1740411440
+    curl -o chef-migration-tool.v1.tar.gz https://chef-hab-migration-tool-bucket.s3.amazonaws.com/migration-tools_Linux_x86_64.tar.gz\?AWSAccessKeyId\=AKIAW4FPVFT6LUYZUYOB\&Signature\=2P3xjN53%2Bib%2BnZBqFk5%2FsEORUzI%3D\&Expires\=1747912109
     ```
 
     Using Wget:
 
     ```sh
-    wget -O "chef-migration-tool.v1.tar.gz" https://chef-hab-migration-tool-bucket.s3.amazonaws.com/migration-tools_Linux_x86_64.tar.gz\?AWSAccessKeyId\=AKIAW4FPVFT6LUYZUYOB\&Signature\=FMsMGzoZe1YTYA4DbpOIEB%2FHHSw%3D\&Expires\=1740411440
+    wget -O "chef-migration-tool.v1.tar.gz" https://chef-hab-migration-tool-bucket.s3.amazonaws.com/migration-tools_Linux_x86_64.tar.gz\?AWSAccessKeyId\=AKIAW4FPVFT6LUYZUYOB\&Signature\=2P3xjN53%2Bib%2BnZBqFk5%2FsEORUzI%3D\&Expires\=1747912109
     ```
 
 1. Extract the migration tool in a temporary directory.
@@ -89,7 +89,7 @@ Chef Infra Client 19 RC1 is supported on Linux x86-64 systems.
 1. Upgrade Chef Infra Client RC1 using the migration tool.
 
     ```sh
-    sudo ./chef-migrate apply online --preserve true --download.url "https://unstable-habitat-tarball.s3.amazonaws.com/chef-chef-infra-client-19.0.54-20241121145703.tar.gz?AWSAccessKeyId=AKIA2L25YRBIC3WVJTRM&Signature=XDGliip78EyaiazMnbi7N8Pao%2Bk%3D&Expires=1740407376" --license.key <VALID_LICENSE_KEY>
+    sudo ./chef-migrate apply online --preserve true --download.url "https://unstable-habitat-tarball.s3.amazonaws.com/chef-chef-infra-client-19.0.54-20241121145703.tar.gz?AWSAccessKeyId=AKIA2L25YRBIC3WVJTRM&Signature=Kp6oGpPRqwiNEhKh8UWlUPJZ6DU%3D&Expires=1747912507" --license.key <VALID_LICENSE_KEY>
     ```
 
     Replace `<VALID_LICENSE_KEY>` with a valid license key.


### PR DESCRIPTION
## Description

Existing S3 buckets are about to expire. Replace with new URLs.

## Version

These are changes for Chef Infra Client version(s):

- [ ] RC1
- [ ] RC2
- [ ] version 19

<!-- Include the version that this updates. -->

## Definition of done

## Issues resolved

- CHEF-19437

## Related PRs

## Checklist

- [ ] spellcheck
- [ ] use [relref shortcode](https://gohugo.io/content-management/cross-references/#use-of-ref-and-relref) for links to Client docs in this doc set
- [ ] all tests pass
