### PR TITLE
Updates RC1 docs

### DIFF
--- a/content/kitchen/run_test_kitchen_enterprise.md
+++ b/content/kitchen/run_test_kitchen_enterprise.md
@@ -9,11 +9,13 @@ parent = "kitchen"
 weight = 40
 +++
 
-For the Chef Infra Client RC1 release, Chef Test Kitchen Enterprise supports the kitchen-dokken driver only and it's a default driver.
-This allows us to create containers, using Podman or Docker Desktop, of various realistic operating systems and configure Chef Infra Client 19 for converge and verify operations.
-By default, this driver uses the chef/chef-hab container volume from Docker Hub to attach the Chef Infra Client 19 and Chef InSpec 6 (the default verifier) to the test container.
+For the Chef Infra Client RC1 release, Chef Test Kitchen Enterprise supports only the kitchen-dokken driver.
+This driver allows you to create containers with different operating systems using Podman or Docker Desktop and configure Chef Infra Client 19 for converge and verify operations.
+By default, kitchen-dokken uses the `chef/chef-hab` container volume from Docker Hub to attach Chef Infra Client 19 and Chef InSpec 6 (the default verifier) to the test container.
 
-**Prerequisite:** `kitchen-dokken` requires Docker to be running on the system where Chef Test Kitchen Enterprise is running.
+## Prerequisites
+
+To use kitchen-dokken, you must have Docker running on the same system that's running Chef Test Kitchen Enterprise.
 
 ## Example `kitchen.yaml` for Chef Infra Client 19
 

--- a/content/kitchen/run_test_kitchen_enterprise.md
+++ b/content/kitchen/run_test_kitchen_enterprise.md
@@ -9,9 +9,11 @@ parent = "kitchen"
 weight = 40
 +++
 
-For the Chef Infra Client RC1 release, Chef Test Kitchen Enterprise supports the kitchen-dokken driver.
+For the Chef Infra Client RC1 release, Chef Test Kitchen Enterprise supports the kitchen-dokken driver only and it is a default driver.
 This allows us to create containers, using Podman or Docker Desktop, of various realistic operating systems and configure Chef Infra Client 19 for converge and verify operations.
 By default, this driver uses the chef/chef-hab container volume from Docker Hub to attach the Chef Infra Client 19 and Chef InSpec 6 (the default verifier) to the test container.
+
+**Prerequisite:** `kitchen-dokken` requires Docker to be running on the system where Chef Test Kitchen Enterprise is running.
 
 ## Example `kitchen.yaml` for Chef Infra Client 19
 

--- a/content/kitchen/run_test_kitchen_enterprise.md
+++ b/content/kitchen/run_test_kitchen_enterprise.md
@@ -9,7 +9,7 @@ parent = "kitchen"
 weight = 40
 +++
 
-For the Chef Infra Client RC1 release, Chef Test Kitchen Enterprise supports the kitchen-dokken driver only and it is a default driver.
+For the Chef Infra Client RC1 release, Chef Test Kitchen Enterprise supports the kitchen-dokken driver only and it's a default driver.
 This allows us to create containers, using Podman or Docker Desktop, of various realistic operating systems and configure Chef Infra Client 19 for converge and verify operations.
 By default, this driver uses the chef/chef-hab container volume from Docker Hub to attach the Chef Infra Client 19 and Chef InSpec 6 (the default verifier) to the test container.
 

--- a/content/license/troubleshooting.md
+++ b/content/license/troubleshooting.md
@@ -17,7 +17,7 @@ This error occurs when a license key that's set with Chef Infra Client isn't ent
 
 To troubleshoot:`
 
-- Run the `chef-client license list` command to view the products your key is entitled to.
+- Run the `chef-client --license-list` command to view the products your key is entitled to.
 - If Chef Infra isn't listed, set a license key that's entitled to Chef Infra.
 
 See the [Chef licensing documentation]({{< relref "/license" >}}) for more information on setting appropriate entitlements.


### PR DESCRIPTION
## Description
Updated the RC1 docs for test kitchen enterprise default driver and troubleshooting page for licensing
<!-- Describe what this change achieves -->

## Version

These are changes for Chef Infra Client version(s):

- [x] RC1
- [ ] RC2
- [ ] version 19

<!-- Include the version that this updates. -->

## Definition of done

## Issues resolved

- https://progresssoftware.atlassian.net/browse/CHEF-19503
- https://progresssoftware.atlassian.net/browse/CHEF-18788

## Related PRs

## Checklist

- [ ] spellcheck
- [ ] use [relref shortcode](https://gohugo.io/content-management/cross-references/#use-of-ref-and-relref) for links to Client docs in this doc set
- [ ] all tests pass
