### PR TITLE
Making the docs match the codebase

### DIFF
--- a/content/integrations/windows.md
+++ b/content/integrations/windows.md
@@ -48,27 +48,9 @@ have access to Chef Infra Server using HTTPS. The Chef Infra Client can be
 used to manage machines that run on the following versions of Microsoft
 Windows:
 
-<table>
-<colgroup>
-<col style="width: 33%" />
-<col style="width: 33%" />
-<col style="width: 33%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>Operating System</th>
-<th>Architecture</th>
-<th>Version</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Windows</td>
-<td><code>x64</code></td>
-<td><code>10</code>, <code>11</code>, <code>Server 2016</code>, <code>Server 2019</code>, <code>Server 2022</code></td>
-</tr>
-</tbody>
-</table>
+| Operating System | Architecture | Version                                                 |
+| ---------------- | ------------ | ------------------------------------------------------- |
+| Windows          | `x64`        | `10`, `11`, `Server 2016`, `Server 2019`, `Server 2022` |
 
 After Chef Infra Client is installed, it's located at `C:\hab`. The
 main configuration file for Chef Infra Client is located at

--- a/content/integrations/windows.md
+++ b/content/integrations/windows.md
@@ -64,13 +64,13 @@ Windows:
 <tbody>
 <tr>
 <td>Windows</td>
-<td><code>x86</code>, <code>x64</code></td>
-<td><code>8.1</code>, <code>2012</code>, <code>2012 R2</code>, <code>2016</code>, <code>10 (all channels except "insider" builds)</code>, <code>2019 (Long-term servicing channel (LTSC), both Desktop Experience and Server Core)</code></td>
+<td><code>x64</code></td>
+<td><code>10</code>, <code>11</code>, <code>Server 2016</code>, <code>Server 2019</code>, <code>Server 2022</code></td>
 </tr>
 </tbody>
 </table>
 
-After Chef Infra Client is installed, it's located at `C:\opscode`. The
+After Chef Infra Client is installed, it's located at `C:\hab`. The
 main configuration file for Chef Infra Client is located at
 `C:\chef\client.rb`.
 

--- a/content/resources/bundled/chef_client_hab_ca_cert.md
+++ b/content/resources/bundled/chef_client_hab_ca_cert.md
@@ -1,0 +1,19 @@
++++
+title = "chef_client_hab_ca_cert Resource"
+draft = false
+robots = ""
+
+data_path = ["infra","resources","chef_client_hab_ca_cert"]
+layout = "infra_resource"
+toc_layout = "infra_resource_toc"
+
+[menu]
+  [menu.resources]
+    title = "chef_client_hab_ca_cert"
+    identifier = "resources/bundled/chef_client_hab_ca_cert"
+    parent = "resources/bundled"
++++
+
+<!-- The contents of this page are automatically generated from the chef_client_hab_ca_cert.yaml file in the data/infra/resources directory. -->
+<!-- To suggest a change, edit the https://github.com/chef/chef/blob/main/lib/chef/resource/chef_client_hab_ca_cert.rb file and submit a pull request to the https://github.com/chef/chef repository. -->
+<!-- markdownlint-disable-file -->

--- a/content/resources/bundled/macos_pkg.md
+++ b/content/resources/bundled/macos_pkg.md
@@ -1,0 +1,19 @@
++++
+title = "macos_pkg Resource"
+draft = false
+robots = ""
+
+data_path = ["infra","resources","macos_pkg"]
+layout = "infra_resource"
+toc_layout = "infra_resource_toc"
+
+[menu]
+  [menu.resources]
+    title = "macos_pkg"
+    identifier = "resources/bundled/macos_pkg"
+    parent = "resources/bundled"
++++
+
+<!-- The contents of this page are automatically generated from the macos_pkg.yaml file in the data/infra/resources directory. -->
+<!-- To suggest a change, edit the https://github.com/chef/chef/blob/main/lib/chef/resource/macos_pkg.rb file and submit a pull request to the https://github.com/chef/chef repository. -->
+<!-- markdownlint-disable-file -->

--- a/data/infra/resources/apt_package.yaml
+++ b/data/infra/resources/apt_package.yaml
@@ -80,7 +80,7 @@ properties_list:
   ruby_type: Hash
   required: false
   default_value: "{}"
-  new_in: '18.8'
+  new_in: '19.0'
   description_list:
   - markdown: A Hash of environment variables in the form of {'ENV_VARIABLE' => 'VALUE'}
       to be set before running the command.

--- a/data/infra/resources/bash.yaml
+++ b/data/infra/resources/bash.yaml
@@ -12,6 +12,7 @@ resource_description_list:
     in which they are run. Use `not_if` and `only_if` to guard this resource for idempotence.
 syntax_full_code_block: |-
   bash 'name' do
+    cgroup           String
     code             String
     command          String, Array # default value: 'name' unless specified
     creates          String
@@ -38,15 +39,23 @@ syntax_full_properties_list:
 - "`name` is the name given to the resource block."
 - "`action` identifies which steps Chef Infra Client will take to bring the node into
   the desired state."
-- "`code`, `command`, `creates`, `cwd`, `default_env`, `domain`, `elevated`, `environment`,
-  `flags`, `group`, `input`, `interpreter`, `live_stream`, `login`, `password`, `returns`,
-  `timeout`, and `user` are the properties available to this resource."
+- "`cgroup`, `code`, `command`, `creates`, `cwd`, `default_env`, `domain`, `elevated`,
+  `environment`, `flags`, `group`, `input`, `interpreter`, `live_stream`, `login`,
+  `password`, `returns`, `timeout`, and `user` are the properties available to this
+  resource."
 actions_list:
   :nothing:
     shortcode: resources_common_actions_nothing.md
   :run:
     markdown: Run a command. (default)
 properties_list:
+- property: cgroup
+  ruby_type: String
+  required: false
+  new_in: '19.0'
+  description_list:
+  - markdown: 'Linux only: Run the command within a specific cgroup, creating it if
+      it doesn''t exist.'
 - property: code
   ruby_type: String
   required: true

--- a/data/infra/resources/chef_client_hab_ca_cert.yaml
+++ b/data/infra/resources/chef_client_hab_ca_cert.yaml
@@ -1,0 +1,75 @@
+---
+resource_reference: true
+resources_common_guards: true
+resources_common_notification: true
+resources_common_properties: true
+resource: chef_client_hab_ca_cert
+resource_description_list:
+- markdown: Use the **chef_client_hab_ca_cert** resource to add certificates to the
+    Habitat Chef Infra Client's CA bundle. This allows Chef Infra Client to communicate
+    with internal encrypted resources without errors. To make sure these CA certs
+    take effect, configure the `ssl_ca_file` to point to the CA cert file path of
+    the `core/cacerts` Habitat package.
+resource_new_in: '19.1'
+syntax_full_code_block: |-
+  chef_client_hab_ca_cert 'name' do
+    cert_name        String # default value: 'name' unless specified
+    certificate      String
+    action           Symbol # defaults to :add if not specified
+  end
+syntax_properties_list:
+syntax_full_properties_list:
+- "`chef_client_hab_ca_cert` is the resource."
+- "`name` is the name given to the resource block."
+- "`action` identifies which steps Chef Infra Client will take to bring the node into
+  the desired state."
+- "`cert_name` and `certificate` are the properties available to this resource."
+actions_list:
+  :nothing:
+    shortcode: resources_common_actions_nothing.md
+  :add:
+    markdown: Add a local certificate to the Habitat Chef Infra Client's CA bundle.
+      (default)
+properties_list:
+- property: cert_name
+  ruby_type: String
+  required: false
+  default_value: The resource block's name
+  description_list:
+  - markdown: The name to use for the certificate. If not provided, the name of the
+      resource block will be used instead.
+- property: certificate
+  ruby_type: String
+  required: true
+  description_list:
+  - markdown: The text of the certificate file including the BEGIN/END comment lines.
+examples: |
+  **Trust a self-signed certificate**:
+
+  ```ruby
+  chef_client_hab_ca_cert 'self-signed.badssl.com' do
+    certificate <<~CERT
+    -----BEGIN CERTIFICATE-----
+    MIIDeTCCAmGgAwIBAgIJAPziuikCTox4MA0GCSqGSIb3DQEBCwUAMGIxCzAJBgNV
+    BAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNp
+    c2NvMQ8wDQYDVQQKDAZCYWRTU0wxFTATBgNVBAMMDCouYmFkc3NsLmNvbTAeFw0x
+    OTEwMDkyMzQxNTJaFw0yMTEwMDgyMzQxNTJaMGIxCzAJBgNVBAYTAlVTMRMwEQYD
+    VQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ8wDQYDVQQK
+    DAZCYWRTU0wxFTATBgNVBAMMDCouYmFkc3NsLmNvbTCCASIwDQYJKoZIhvcNAQEB
+    BQADggEPADCCAQoCggEBAMIE7PiM7gTCs9hQ1XBYzJMY61yoaEmwIrX5lZ6xKyx2
+    PmzAS2BMTOqytMAPgLaw+XLJhgL5XEFdEyt/ccRLvOmULlA3pmccYYz2QULFRtMW
+    hyefdOsKnRFSJiFzbIRMeVXk0WvoBj1IFVKtsyjbqv9u/2CVSndrOfEk0TG23U3A
+    xPxTuW1CrbV8/q71FdIzSOciccfCFHpsKOo3St/qbLVytH5aohbcabFXRNsKEqve
+    ww9HdFxBIuGa+RuT5q0iBikusbpJHAwnnqP7i/dAcgCskgjZjFeEU4EFy+b+a1SY
+    QCeFxxC7c3DvaRhBB0VVfPlkPz0sw6l865MaTIbRyoUCAwEAAaMyMDAwCQYDVR0T
+    BAIwADAjBgNVHREEHDAaggwqLmJhZHNzbC5jb22CCmJhZHNzbC5jb20wDQYJKoZI
+    hvcNAQELBQADggEBAGlwCdbPxflZfYOaukZGCaxYK6gpincX4Lla4Ui2WdeQxE95
+    w7fChXvP3YkE3UYUE7mupZ0eg4ZILr/A0e7JQDsgIu/SRTUE0domCKgPZ8v99k3A
+    vka4LpLK51jHJJK7EFgo3ca2nldd97GM0MU41xHFk8qaK1tWJkfrrfcGwDJ4GQPI
+    iLlm6i0yHq1Qg1RypAXJy5dTlRXlCLd8ufWhhiwW0W75Va5AEnJuqpQrKwl3KQVe
+    wGj67WWRgLfSr+4QG1mNvCZb2CkjZWmxkGPuoP40/y7Yu5OFqxP5tAjj4YixCYTW
+    EVA0pmzIzgBg+JIe3PdRy27T0asgQW/F4TY61Yk=
+    -----END CERTIFICATE-----
+    CERT
+  end
+  ```

--- a/data/infra/resources/chocolatey_installer.yaml
+++ b/data/infra/resources/chocolatey_installer.yaml
@@ -7,7 +7,7 @@ resource: chocolatey_installer
 resource_description_list:
 - markdown: Use the chocolatey_installer resource to install the Chocolatey package manager. Use the chocolatey_feature resource to customize
     your install and the chocolatey_package resource to install packages.
-resource_new_in: '18.4'
+resource_new_in: '18.3'
 syntax_full_code_block: |-
   chocolatey_installer 'name' do
     chocolatey_version      String

--- a/data/infra/resources/csh.yaml
+++ b/data/infra/resources/csh.yaml
@@ -12,6 +12,7 @@ resource_description_list:
     in which they are run. Use `not_if` and `only_if` to guard this resource for idempotence.
 syntax_full_code_block: |-
   csh 'name' do
+    cgroup           String
     code             String
     command          String, Array # default value: 'name' unless specified
     creates          String
@@ -38,15 +39,23 @@ syntax_full_properties_list:
 - "`name` is the name given to the resource block."
 - "`action` identifies which steps Chef Infra Client will take to bring the node into
   the desired state."
-- "`code`, `command`, `creates`, `cwd`, `default_env`, `domain`, `elevated`, `environment`,
-  `flags`, `group`, `input`, `interpreter`, `live_stream`, `login`, `password`, `returns`,
-  `timeout`, and `user` are the properties available to this resource."
+- "`cgroup`, `code`, `command`, `creates`, `cwd`, `default_env`, `domain`, `elevated`,
+  `environment`, `flags`, `group`, `input`, `interpreter`, `live_stream`, `login`,
+  `password`, `returns`, `timeout`, and `user` are the properties available to this
+  resource."
 actions_list:
   :nothing:
     shortcode: resources_common_actions_nothing.md
   :run:
     markdown: Run a command. (default)
 properties_list:
+- property: cgroup
+  ruby_type: String
+  required: false
+  new_in: '19.0'
+  description_list:
+  - markdown: 'Linux only: Run the command within a specific cgroup, creating it if
+      it doesn''t exist.'
 - property: code
   ruby_type: String
   required: true

--- a/data/infra/resources/dnf_package.yaml
+++ b/data/infra/resources/dnf_package.yaml
@@ -80,7 +80,7 @@ properties_list:
   ruby_type: Hash
   required: false
   default_value: "{}"
-  new_in: '18.8'
+  new_in: '19.0'
   description_list:
   - markdown: A Hash of environment variables in the form of {'ENV_VARIABLE' => 'VALUE'}
       to be set before running the command.

--- a/data/infra/resources/dpkg_package.yaml
+++ b/data/infra/resources/dpkg_package.yaml
@@ -55,7 +55,7 @@ properties_list:
   ruby_type: Hash
   required: false
   default_value: "{}"
-  new_in: '18.8'
+  new_in: '19.0'
   description_list:
   - markdown: A Hash of environment variables in the form of {'ENV_VARIABLE' => 'VALUE'}
       to be set before running the command.

--- a/data/infra/resources/execute.yaml
+++ b/data/infra/resources/execute.yaml
@@ -58,6 +58,7 @@ syntax_properties_list:
   that file already exists'
 syntax_full_code_block: |-
   execute 'name' do
+    cgroup           String
     command          String, Array # default value: 'name' unless specified
     creates          String
     cwd              String
@@ -80,15 +81,22 @@ syntax_full_properties_list:
 - "`name` is the name given to the resource block."
 - "`action` identifies which steps Chef Infra Client will take to bring the node into
   the desired state."
-- "`command`, `creates`, `cwd`, `default_env`, `domain`, `elevated`, `environment`,
-  `group`, `input`, `live_stream`, `login`, `password`, `returns`, `timeout`, and
-  `user` are the properties available to this resource."
+- "`cgroup`, `command`, `creates`, `cwd`, `default_env`, `domain`, `elevated`,
+  `environment`, `group`, `input`, `live_stream`, `login`, `password`, `returns`,
+  `timeout`, and `user` are the properties available to this resource."
 actions_list:
   :nothing:
     shortcode: resources_common_actions_nothing.md
   :run:
     markdown: Run a command. (default)
 properties_list:
+- property: cgroup
+  ruby_type: String
+  required: false
+  new_in: '19.0'
+  description_list:
+  - markdown: 'Linux only: Run the command within a specific cgroup, creating it if
+      it doesn''t exist.'
 - property: command
   ruby_type: String, Array
   required: false

--- a/data/infra/resources/file.yaml
+++ b/data/infra/resources/file.yaml
@@ -360,7 +360,7 @@ remote_file_unc_path: false
 ps_credential_helper: false
 ruby_style_basics_chef_log: false
 debug_recipes_chef_shell: false
-examples: |2
+examples: |-
    **Create a file**
 
     ```ruby

--- a/data/infra/resources/gem_package.yaml
+++ b/data/infra/resources/gem_package.yaml
@@ -16,6 +16,7 @@ resource_description_list:
 syntax_full_code_block: |-
   gem_package 'name' do
     clear_sources               true, false
+    environment                 Hash
     gem_binary                  String
     include_default_source      true, false
     options                     String, Hash, Array
@@ -31,8 +32,9 @@ syntax_full_properties_list:
 - "`name` is the name given to the resource block."
 - "`action` identifies which steps Chef Infra Client will take to bring the node into
   the desired state."
-- "`clear_sources`, `gem_binary`, `include_default_source`, `options`, `package_name`,
-  `source`, `timeout`, and `version` are the properties available to this resource."
+- "`clear_sources`, `environment`, `gem_binary`, `include_default_source`, `options`,
+  `package_name`, `source`, `timeout`, and `version` are the properties available
+  to this resource."
 actions_list:
   :install:
     markdown: Install a package. If a version is specified, install the specified
@@ -52,6 +54,14 @@ properties_list:
   description_list:
   - markdown: Set to `true` to download a gem from the path specified by the `source`
       property (and not from RubyGems).
+- property: environment
+  ruby_type: Hash
+  required: false
+  new_in: '19.0'
+  description_list:
+  - markdown: 'A Hash of environment variables in the form of `({''ENV_VARIABLE''
+      => ''VALUE''})`. **Note**: These variables must exist for a command to be run
+      successfully.'
 - property: gem_binary
   ruby_type: String
   required: false

--- a/data/infra/resources/inspec_input.yaml
+++ b/data/infra/resources/inspec_input.yaml
@@ -38,7 +38,7 @@ properties_list:
   default_value: The resource block's name
   description_list:
   - markdown:
-examples: |2
+examples: |-
 
   **Activate the default input in the openssh cookbook's compliance segment**:
 

--- a/data/infra/resources/ksh.yaml
+++ b/data/infra/resources/ksh.yaml
@@ -28,6 +28,7 @@ syntax_description: |
   - `code` specifies the command to run.
 syntax_full_code_block: |-
   ksh 'name' do
+    cgroup                     String
     code                       String
     creates                    String
     cwd                        String
@@ -48,7 +49,7 @@ syntax_full_properties_list:
 - "`name` is the name given to the resource block."
 - "`action` identifies which steps Chef Infra Client will take to bring the node into
   the desired state."
-- "`code`, `creates`, `cwd`, `environment`,
+- "`cgroup`, `code`, `creates`, `cwd`, `environment`,
   `flags`, `group`, `input`, `path`, `returns`,
   `timeout`, `user`, and `umask` are the properties available to this resource."
 actions_list:
@@ -57,6 +58,13 @@ actions_list:
   :run:
     markdown: Run a command. (default)
 properties_list:
+- property: cgroup
+  ruby_type: String
+  required: false
+  new_in: '19.0'
+  description_list:
+  - markdown: 'Linux only: Run the command within a specific cgroup, creating it if
+      it doesn''t exist.'
 - property: code
   ruby_type: String
   required: true

--- a/data/infra/resources/macos_pkg.yaml
+++ b/data/infra/resources/macos_pkg.yaml
@@ -1,0 +1,89 @@
+---
+resource_reference: true
+resources_common_guards: true
+resources_common_notification: true
+resources_common_properties: true
+resource: macos_pkg
+resource_description_list:
+- markdown: Use the **macos_pkg** resource to install a macOS `.pkg` file, optionally
+    downloading it from a remote source. A `package_id` property must be provided
+    for idempotency. Either a `file` or `source` property is required.
+resource_new_in: '18.1'
+syntax_full_code_block: |-
+  macos_pkg 'name' do
+    checksum         String
+    file             String
+    headers          Hash
+    package_id       String
+    source           String
+    target           String # default value: '/'
+    action           Symbol # defaults to :install if not specified
+  end
+syntax_properties_list:
+syntax_full_properties_list:
+- "`macos_pkg` is the resource."
+- "`name` is the name given to the resource block."
+- "`action` identifies which steps Chef Infra Client will take to bring the node into
+  the desired state."
+- "`checksum`, `file`, `headers`, `package_id`, `source`, and `target` are the properties
+  available to this resource."
+actions_list:
+  :nothing:
+    shortcode: resources_common_actions_nothing.md
+  :install:
+    markdown: Install a macOS `.pkg` file. (default)
+properties_list:
+- property: checksum
+  ruby_type: String
+  required: false
+  description_list:
+  - markdown: The SHA-256 checksum of the `.pkg` file to download.
+- property: file
+  ruby_type: String
+  required: false
+  description_list:
+  - markdown: The absolute path to the `.pkg` file on the local system.
+- property: headers
+  ruby_type: Hash
+  required: false
+  description_list:
+  - markdown: Allows custom HTTP headers (such as cookies) to be set on the `remote_file`
+      resource used to download the package.
+- property: package_id
+  ruby_type: String
+  required: true
+  description_list:
+  - markdown: The package ID registered with `pkgutil` when a `pkg` or `mpkg` is
+      installed. Required for idempotency.
+- property: source
+  ruby_type: String
+  required: false
+  description_list:
+  - markdown: The remote URL used to download the `.pkg` file.
+- property: target
+  ruby_type: String
+  required: false
+  default_value: /
+  description_list:
+  - markdown: The device to install the package on.
+examples: |
+  **Install osquery**:
+
+  ```ruby
+  macos_pkg 'osquery' do
+    checksum   '1fea8ac9b603851d2e76c5fc73138a468a3075a3002c8cb1fd7fff53b889c4dd'
+    package_id 'io.osquery.agent'
+    source     'https://pkg.osquery.io/darwin/osquery-5.8.2.pkg'
+    action     :install
+  end
+  ```
+
+  **Install a local package**:
+
+  ```ruby
+  macos_pkg 'my-app' do
+    file       '/tmp/my-app.pkg'
+    package_id 'com.example.my-app'
+    action     :install
+  end
+  ```

--- a/data/infra/resources/package.yaml
+++ b/data/infra/resources/package.yaml
@@ -126,7 +126,7 @@ properties_list:
   ruby_type: Hash
   required: false
   default_value: "{}"
-  new_in: '18.8'
+  new_in: '19.0'
   description_list:
   - markdown: A Hash of environment variables in the form of {'ENV_VARIABLE' => 'VALUE'}
       to be set before running the command.

--- a/data/infra/resources/perl.yaml
+++ b/data/infra/resources/perl.yaml
@@ -23,6 +23,7 @@ syntax_description: |
     `code` specifies the command to run.
 syntax_full_code_block: |-
   perl 'name' do
+    cgroup           String
     code             String
     command          String, Array # default value: 'name' unless specified
     creates          String
@@ -50,7 +51,7 @@ syntax_full_properties_list:
 - "`name` is the name given to the resource block."
 - "`action` identifies which steps Chef Infra Client will take to bring the node into
   the desired state."
-- "`code`, `creates`, `cwd`, `environment`,
+- "`cgroup`, `code`, `creates`, `cwd`, `environment`,
   `flags`, `group`, `ignore_failure`, `notifies`, `returns`,
   `subscribes`,`timeout`, `user`, and `umask` are the properties available to this resource."
 actions_list:
@@ -59,6 +60,13 @@ actions_list:
   :run:
     markdown: Run a command. (default)
 properties_list:
+- property: cgroup
+  ruby_type: String
+  required: false
+  new_in: '19.0'
+  description_list:
+  - markdown: 'Linux only: Run the command within a specific cgroup, creating it if
+      it doesn''t exist.'
 - property: code
   ruby_type: String
   required: true

--- a/data/infra/resources/python.yaml
+++ b/data/infra/resources/python.yaml
@@ -20,6 +20,7 @@ syntax_description: |
   ```
 syntax_full_code_block: |-
   python 'name' do
+    cgroup           String
     code             String
     command          String, Array # default value: 'name' unless specified
     creates          String
@@ -46,15 +47,23 @@ syntax_full_properties_list:
 - "`name` is the name given to the resource block."
 - "`action` identifies which steps Chef Infra Client will take to bring the node into
   the desired state."
-- "`code`, `command`, `creates`, `cwd`, `default_env`, `domain`, `elevated`, `environment`,
-  `flags`, `group`, `input`, `interpreter`, `live_stream`, `login`, `password`, `returns`,
-  `timeout`, and `user` are the properties available to this resource."
+- "`cgroup`, `code`, `command`, `creates`, `cwd`, `default_env`, `domain`, `elevated`,
+  `environment`, `flags`, `group`, `input`, `interpreter`, `live_stream`, `login`,
+  `password`, `returns`, `timeout`, and `user` are the properties available to this
+  resource."
 actions_list:
   :nothing:
     shortcode: resources_common_actions_nothing.md
   :run:
     markdown: Run a command. (default)
 properties_list:
+- property: cgroup
+  ruby_type: String
+  required: false
+  new_in: '19.0'
+  description_list:
+  - markdown: 'Linux only: Run the command within a specific cgroup, creating it if
+      it doesn''t exist.'
 - property: code
   ruby_type: String
   required: true

--- a/data/infra/resources/rpm_package.yaml
+++ b/data/infra/resources/rpm_package.yaml
@@ -47,7 +47,7 @@ properties_list:
   ruby_type: Hash
   required: false
   default_value: "{}"
-  new_in: '18.8'
+  new_in: '19.0'
   description_list:
   - markdown: A Hash of environment variables in the form of {'ENV_VARIABLE' => 'VALUE'}
       to be set before running the command.

--- a/data/infra/resources/ruby.yaml
+++ b/data/infra/resources/ruby.yaml
@@ -18,6 +18,7 @@ syntax_description: |
   ```
 syntax_full_code_block: |-
   ruby 'name' do
+    cgroup           String
     code             String
     creates          String
     cwd              String
@@ -41,7 +42,7 @@ syntax_full_properties_list:
 - "`name` is the name given to the resource block."
 - "`action` identifies which steps Chef Infra Client will take to bring the node into
   the desired state."
-- "`code`, `creates`, `cwd`, `environment`, `flags`,
+- "`cgroup`, `code`, `creates`, `cwd`, `environment`, `flags`,
   `group`, `ignore_failure`, `notifies`, `returns`, `subscribes`
   `timeout`, `user`, and `umask` are the properties available to this resource."
 actions_list:
@@ -50,6 +51,13 @@ actions_list:
   :run:
     markdown: Run a command. (default)
 properties_list:
+- property: cgroup
+  ruby_type: String
+  required: false
+  new_in: '19.0'
+  description_list:
+  - markdown: 'Linux only: Run the command within a specific cgroup, creating it if
+      it doesn''t exist.'
 - property: code
   ruby_type: String
   required: true

--- a/data/infra/resources/windows_package.yaml
+++ b/data/infra/resources/windows_package.yaml
@@ -4,6 +4,7 @@ resources_common_guards: true
 resources_common_notification: true
 resources_common_properties: true
 resource: windows_package
+resource_new_in: '11.12'
 resource_description_list:
 - markdown: |-
     Use the **windows_package** resource to manage packages on the Microsoft Windows platform.

--- a/data/infra/resources/yum_package.yaml
+++ b/data/infra/resources/yum_package.yaml
@@ -73,7 +73,7 @@ properties_list:
   ruby_type: Hash
   required: false
   default_value: "{}"
-  new_in: '18.8'
+  new_in: '19.0'
   description_list:
   - markdown: A Hash of environment variables in the form of {'ENV_VARIABLE' => 'VALUE'}
       to be set before running the command.

--- a/layouts/_default/infra_resource.html
+++ b/layouts/_default/infra_resource.html
@@ -18,15 +18,6 @@
   <p data-swiftype-index='false'><a href="/{{ $product }}/resources/">All {{ $product | title }} resources page</a></p>
 {{ end }}
 
-<hr>
-
-<div class="admonition-warning">
-  <p class="admonition-warning-title">Warning</p>
-  <div class="admonition-warning-text">
-    Progress Chef is currently reviewing the Chef Infra Client 19 resource documentation for accuracy and updating it. Please test your cookbooks accordingly.
-  </div>
-</div>
-
 {{ $yaml_file := index $.Site.Data (.Params.data_path) }}
 {{ $partial_data := dict "yaml_file" $yaml_file "product" $product "resource_ID" "" "heading_base_level" 2 "include_resource_id" false }}
 {{ partial "infra_resource_data" $partial_data }}

--- a/layouts/_default/infra_resources_all.html
+++ b/layouts/_default/infra_resources_all.html
@@ -2,13 +2,6 @@
 {{ define "main" }}
   {{ $product := index .Params.data_path 0 }}
 
-  <div class="admonition-warning">
-    <p class="admonition-warning-title">Warning</p>
-    <div class="admonition-warning-text">
-      Progress Chef is currently reviewing the Chef Infra Client 19 resource documentation for accuracy and updating it. Please test your cookbooks accordingly.
-    </div>
-  </div>
-
   {{ .Content }}
 
   {{ range $yaml_file := index $.Site.Data ( .Params.data_path )}}


### PR DESCRIPTION
## Description

Using the tools at hand, I am trying to make the docs match the codebase. I audited the online docs and then brought the results of that to chef and compared them. Then I took THOSE results and brought them here to update. It turns out that a number of things missing online are already here but not published yet. This should update a number of things to bring the docs into closer parity with the codebase.

## Version

These are changes for Chef Infra Client versions: 19.2

<!-- Include the version that this updates. -->

## Definition of done

## Issues resolved

<!-- List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant -->

## Related PRs

## Checklist

- [ ] spellcheck
- [ ] use [relref shortcode](https://gohugo.io/content-management/cross-references/#use-of-ref-and-relref) for links to Client docs in this doc set
- [ ] all tests pass
